### PR TITLE
Fixed User#to_s

### DIFF
--- a/lib/scribd/user.rb
+++ b/lib/scribd/user.rb
@@ -187,7 +187,7 @@ module Scribd
 
     # @private
     def to_s
-      @attributes[:username]
+      @attributes[:username].to_s
     end
   end
 end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -278,6 +278,17 @@ describe Scribd::User do
       Scribd::API.instance.user.should eql(user)
     end
   end
+  
+  describe "User without attributes" do
+    before :each do
+      @user = Scribd::User.new()
+    end
+    
+    it "should return an empty string when requested for its string representation" do
+      @user.to_s.should eql('')
+    end
+  end
+  
 end
 
 Dir.chdir old_dir


### PR DESCRIPTION
I was getting a "can't convert nil into String" from Resource#inspect when trying to upload a file with a session_key and without any user logged in.

```
doc = Scribd::Document.upload(:file => File.new("file.pdf"), :session_key => 'secret')
```

That was because User#to_s return nil, I changed it to return an empty string instead.
